### PR TITLE
Ignore old protocol when full resync (with empty folder) is made

### DIFF
--- a/src/version.h
+++ b/src/version.h
@@ -21,7 +21,7 @@ static const int INIT_PROTO_VERSION = 209;
 static const int GETHEADERS_VERSION = 70077;
 
 //! disconnect from peers older than this proto version
-static const int MIN_PEER_PROTO_VERSION_BEFORE_ENFORCEMENT = 70811;
+static const int MIN_PEER_PROTO_VERSION_BEFORE_ENFORCEMENT = 70820;
 static const int MIN_PEER_PROTO_VERSION_AFTER_ENFORCEMENT15 = 70820;
 static const int MIN_PEER_PROTO_VERSION_AFTER_ENFORCEMENT17 = 70830;
 


### PR DESCRIPTION
Now, when pools are synced - we need to ignore old protocols at start of resync...
Without that it syncs to all nodes before reaching 97k height where spork was activated and keeps connected old...