### PR TITLE
Remove broken seeders + add a 1.2.3 seeder.

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -143,18 +143,7 @@ public:
 	assert(genesis.hashMerkleRoot == uint256("0x77976d6bd593c84063ac3937525bc15e25188d96871b13d4451ffc382999f64f"));
 
 	vSeeds.push_back(CDNSSeedData("mempool.pw", "bwkseed.mempool.pw"));
-        vSeeds.push_back(CDNSSeedData("ssus.tech", "bulwark-dns-seed04.ssus.tech"));
-	vSeeds.push_back(CDNSSeedData("blocksuckernation.com", "bwkseed.blocksuckernation.com"));
-	vSeeds.push_back(CDNSSeedData("bwk1.masterhash.us", "bwk1.masterhash.us"));      // Single node address
-        vSeeds.push_back(CDNSSeedData("bwk2.masterhash.us", "bwk2.masterhash.us")); 	 // Single node address
-        vSeeds.push_back(CDNSSeedData("bwk3.masterhash.us", "bwk3.masterhash.us"));      // Single node address
-	vSeeds.push_back(CDNSSeedData("bwk4.masterhash.us", "bwk4.masterhash.us"));      // Single node address
-        vSeeds.push_back(CDNSSeedData("bwk5.masterhash.us", "bwk5.masterhash.us"));      // Single node address
-        vSeeds.push_back(CDNSSeedData("bwk6.masterhash.us", "bwk6.masterhash.us"));      // Single node address
-	vSeeds.push_back(CDNSSeedData("bwk7.masterhash.us", "bwk7.masterhash.us"));      // Single node address
-        vSeeds.push_back(CDNSSeedData("bwk8.masterhash.us", "bwk8.masterhash.us"));      // Single node address
-        vSeeds.push_back(CDNSSeedData("bwk9.masterhash.us", "bwk9.masterhash.us"));      // Single node address
-	vSeeds.push_back(CDNSSeedData("bwk10.masterhash.us", "bwk10.masterhash.us"));    // Single node address
+	vSeeds.push_back(CDNSSeedData("penple.org", "bwkseed.penple.org"));
         
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1, 85); // b
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1, 18); 


### PR DESCRIPTION
The masterhash nodes don't appear to work properly and the ssus.tech and blocksuckernation.com seeders seem to be down entirely.
The mempool.pw node is still up, however it is broadcasting older clients.
The penple.org seeder has been added because it only broadcasts 1.2.3 clients.