### PR TITLE
Use correct COINBASE_MATURITY value in MultiSend

### DIFF
--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -3734,7 +3734,7 @@ bool CWallet::MultiSend()
     bool mnSent = false;
     for (const COutput& out : vCoins) {
         //need output with precise confirm count - this is how we identify which is the output to send
-        if (out.tx->GetDepthInMainChain() != COINBASE_MATURITY + 1)
+        if (out.tx->GetDepthInMainChain() != Params().COINBASE_MATURITY() + 1)
             continue;
 
         COutPoint outpoint(out.tx->GetHash(), out.i);


### PR DESCRIPTION
Multisend was using incorrect block maturity (100) rather than correct block maturity (67)