### PR TITLE
Fix build for unsupported qt version 5.5.1

### DIFF
--- a/src/qt/bulwark.cpp
+++ b/src/qt/bulwark.cpp
@@ -502,7 +502,9 @@ int main(int argc, char* argv[]) {
 
     BitcoinApplication app(argc, argv);
     QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
+#if QT_VERSION >= 0x050600
     QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+#endif
 #ifdef Q_OS_MAC
     QApplication::setAttribute(Qt::AA_DontShowIconsInMenus);
 #endif


### PR DESCRIPTION
The default qt version available in the Ubuntu xenial 16.04 package sources is currently 5.5.1.
https://launchpad.net/ubuntu/xenial/+package/qt5-default

This pull request adds a simple preprocessor directive that will fix the building on ubuntu xenial 16.04
with default packages. Reverts parts of 01956126b68a4275ade0c4da833066479f53583f.

